### PR TITLE
24082016 add multiple accounts per user

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -420,3 +420,23 @@ func retrieveAccount(data []string) (accountIDs []string, err error) {
 
 	return
 }
+
+func CheckUserAccountValidFromToken(userID string, accountNumber string) (err error) {
+	// Get list of accounts from userID
+	userAccountNumbers, err := getAllAccountNumbersByID(userID)
+	if err != nil {
+		return errors.New("accounts.CheckUserAccountValidFromToken: " + err.Error())
+	}
+
+	senderValid := false
+	for _, v := range userAccountNumbers {
+		if strings.Compare(v, accountNumber) == 0 {
+			senderValid = true
+		}
+	}
+
+	if !senderValid {
+		return errors.New("accounts.accounts.CheckUserAccountValidFromToken: Sender invalid")
+	}
+	return
+}

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -204,12 +204,6 @@ func openAccount(data []string) (result interface{}, err error) {
 	}
 
 	// Test: acmt~1~Kyle~Redelinghuys~19000101~190001011234098~1112223456~~email@domain.com~Physical Address 1~~~1000
-	// Check if account already exists, check on ID number
-	accountHolder, _ := getAccountMeta(data[6])
-	if accountHolder.AccountNumber != "" {
-		return "", errors.New("accounts.openAccount: Account already open. " + accountHolder.AccountNumber)
-	}
-
 	// @FIXME: Remove new line from data
 	data[len(data)-1] = strings.Replace(data[len(data)-1], "\n", "", -1)
 

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -99,6 +99,7 @@ type AccountDetails struct {
 	AccountBalance    decimal.Decimal
 	Overdraft         decimal.Decimal
 	AvailableBalance  decimal.Decimal
+	Type              string
 	Timestamp         int
 }
 
@@ -267,6 +268,20 @@ func setAccountDetails(data []string) (accountDetails AccountDetails, err error)
 	accountDetails.AccountBalance = decimal.NewFromFloat(OPENING_BALANCE)
 	accountDetails.Overdraft = decimal.NewFromFloat(OPENING_OVERDRAFT)
 	accountDetails.AvailableBalance = decimal.NewFromFloat(OPENING_BALANCE + OPENING_OVERDRAFT)
+	// Get account type
+	accountType := data[14]
+	switch accountType {
+	case "":
+		accountType = "cheque" // Default to chequing account
+		break
+	case "savings", "cheque", "merchant", "money-market", "cd", "ira", "rcp", "credit", "mortgage", "loan":
+		// Valid
+		break
+	default:
+		return AccountDetails{}, errors.New("accounts.setAccountDetails: Account type not valid, must be one of savings, cheque, merchant, money-market, cd, ira, rcp, credit, mortgage, loan")
+		break
+	}
+	accountDetails.Type = accountType
 
 	return
 }

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -132,7 +132,7 @@ func ProcessAccount(data []string) (result interface{}, err error) {
 		}
 		break
 	case 1001:
-		result, err = fetchSingleAccount(data)
+		result, err = fetchUserAccounts(data)
 		if err != nil {
 			return "", errors.New("accounts.ProcessAccount: " + err.Error())
 		}
@@ -299,13 +299,13 @@ func setAccountHolderDetails(data []string) (accountHolderDetails AccountHolderD
 	return
 }
 
-func fetchSingleAccount(data []string) (account interface{}, err error) {
+func fetchUserAccounts(data []string) (account interface{}, err error) {
 	// Fetch user account. Must be user logged in
 	tokenUser, err := appauth.GetUserFromToken(data[0])
 	if err != nil {
 		return "", errors.New("accounts.fetchSingleAccount: " + err.Error())
 	}
-	account, err = getSingleAccountDetail(tokenUser)
+	account, err = getUserAccountsDetail(tokenUser)
 	if err != nil {
 		return "", errors.New("accounts.fetchSingleAccount: " + err.Error())
 	}

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -2,7 +2,6 @@ package accounts
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -195,7 +194,7 @@ func ProcessAccount(data []string) (result interface{}, err error) {
 
 func openAccount(data []string) (result interface{}, err error) {
 	// Validate string against required info/length
-	if len(data) < 14 {
+	if len(data) < 15 {
 		err = errors.New("accounts.openAccount: Not all fields present")
 		return
 	}
@@ -224,7 +223,7 @@ func openAccount(data []string) (result interface{}, err error) {
 
 func closeAccount(data []string) (result interface{}, err error) {
 	// Validate string against required info/length
-	if len(data) < 14 {
+	if len(data) < 15 {
 		err = errors.New("accounts.closeAccount: Not all fields present")
 		return
 	}
@@ -256,7 +255,10 @@ func closeAccount(data []string) (result interface{}, err error) {
 }
 
 func setAccountDetails(data []string) (accountDetails AccountDetails, err error) {
-	fmt.Println(data)
+	if len(data) < 15 {
+		return AccountDetails{}, errors.New("accounts.setAccountDetails: Not all fields required present")
+	}
+
 	if data[4] == "" {
 		return AccountDetails{}, errors.New("accounts.setAccountDetails: Family name cannot be empty")
 	}

--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -52,7 +52,24 @@ func TestOpenCloseAccount(t *testing.T) {
 }
 
 func TestSetAccountDetails(t *testing.T) {
-	tst := []string{"", "", "", "John", "Doe"}
+	tst := []string{
+		"", // 0
+		"", // acmt
+		"", // 1
+		"John",
+		"Doe",
+		"1900-01-01",
+		"19000101-1000-100",
+		"555-123-1234",
+		"",
+		"test@user.com",
+		"Address 1",
+		"Address 2",
+		"Address 3",
+		"22202",
+		"cheque",
+	}
+
 	accountDetails, err := setAccountDetails(tst)
 
 	if err != nil {
@@ -61,10 +78,6 @@ func TestSetAccountDetails(t *testing.T) {
 
 	if reflect.TypeOf(accountDetails).String() != "accounts.AccountDetails" {
 		t.Errorf("SetAccountDetails does not pass. TYPE. Looking for %v, got %v", "accounts.AccountDetails", reflect.TypeOf(accountDetails).String())
-	}
-
-	if accountDetails.BankNumber != BANK_NUMBER {
-		t.Errorf("SetAccountDetails does not pass. DETAILS. Looking for %v, got %v", BANK_NUMBER, accountDetails.BankNumber)
 	}
 
 	if !accountDetails.Overdraft.Equals(decimal.NewFromFloat(OPENING_OVERDRAFT)) {
@@ -93,7 +106,7 @@ func TestSetAccountHolderDetailsFailure(t *testing.T) {
 }
 
 func TestSetAccountHolderDetails(t *testing.T) {
-	tst := []string{"", "", "", "John", "Doe", "01011900", "010119001234123", "111", "222", "user@domain.com", "address 1", "address 2", "address 3", "2000"}
+	tst := []string{"", "", "", "John", "Doe", "01011900", "010119001234123", "111", "222", "user@domain.com", "address 1", "address 2", "address 3", "2000", "cheque"}
 	accountHolderDetails, err := setAccountHolderDetails(tst)
 
 	if err != nil {
@@ -102,10 +115,6 @@ func TestSetAccountHolderDetails(t *testing.T) {
 
 	if reflect.TypeOf(accountHolderDetails).String() != "accounts.AccountHolderDetails" {
 		t.Errorf("SetAccountHolderDetails does not pass. TYPE. Looking for %v, got %v", "accounts.AccountHolderDetails", reflect.TypeOf(accountHolderDetails).String())
-	}
-
-	if accountHolderDetails.BankNumber != BANK_NUMBER {
-		t.Errorf("SetAccountHolderDetails does not pass. DETAILS. Looking for %v, got %v", BANK_NUMBER, accountHolderDetails.BankNumber)
 	}
 
 	if accountHolderDetails.GivenName != "John" {
@@ -155,9 +164,31 @@ func TestSetAccountHolderDetails(t *testing.T) {
 
 func BenchmarkSetAccountHolderDetails(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		tst := []string{"", "", "", "John", "Doe", "01011900", "010119001234123", "111", "222", "user@domain.com", "address 1", "address 2", "address 3", "2000"}
+		tst := []string{"", "", "", "John", "Doe", "01011900", "010119001234123", "111", "222", "user@domain.com", "address 1", "address 2", "address 3", "2000", "cheque"}
 		_, _ = setAccountHolderDetails(tst)
 	}
+}
+
+func TestSetAccountHolderDetailsSuccessAccountType(t *testing.T) {
+	accountTypes := []string{"savings", "cheque", "merchant", "money-market", "cd", "ira", "rcp", "credit", "mortgage", "loan"}
+	for _, v := range accountTypes {
+		tst := []string{"", "", "", "John", "Doe", "01011900", "010119001234123", "111", "222", "user@domain.com", "address 1", "address 2", "address 3", "2000", v}
+		_, err := setAccountHolderDetails(tst)
+
+		if err != nil {
+			t.Errorf("SetAccountHolderDetails does not pass.  Looking for %v, got %v", nil, err)
+		}
+	}
+}
+
+func TestSetAccountHolderDetailsFailureAccountType(t *testing.T) {
+	tst := []string{"", "", "", "John", "Doe", "01011900", "010119001234123", "111", "222", "user@domain.com", "address 1", "address 2", "address 3", "2000", "not-valid-account-type"}
+	_, err := setAccountHolderDetails(tst)
+
+	if err != nil {
+		t.Errorf("SetAccountHolderDetails does not pass.  Looking for %v, got %v", nil, err)
+	}
+
 }
 
 /* @TODO

--- a/accounts/database.go
+++ b/accounts/database.go
@@ -259,10 +259,6 @@ func getAccountUser(id string) (accountDetails AccountHolderDetails, err error) 
 		count++
 	}
 
-	if count == 0 {
-		return AccountHolderDetails{}, errors.New("accounts.getAccountUser: Account not found")
-	}
-
 	return
 }
 

--- a/accounts/database.go
+++ b/accounts/database.go
@@ -93,7 +93,7 @@ func doCreateAccount(sqlTime int32, accountDetails *AccountDetails, accountHolde
 	}
 
 	// We insert a record into account user accounts
-	insertStatement = "INSERT INTO accounts_user_accounts (`accountHolderIdentificationNumber`, `accountNumbe`, `bankNumber`, `timestamp`) "
+	insertStatement = "INSERT INTO accounts_users_accounts (`accountHolderIdentificationNumber`, `accountNumber`, `bankNumber`, `timestamp`) "
 	insertStatement += "VALUES(?, ?, ?, ?)"
 	stmtIns, err = Config.Db.Prepare(insertStatement)
 	if err != nil {
@@ -131,7 +131,7 @@ func doDeleteAccount(accountDetails *AccountDetails) (err error) {
 func doCreateAccountUser(sqlTime int32, accountHolderDetails *AccountHolderDetails, accountDetails *AccountDetails) (err error) {
 	// Create account meta
 	insertStatement := "INSERT INTO accounts_users (`accountHolderGivenName`, `accountHolderFamilyName`, `accountHolderDateOfBirth`, `accountHolderIdentificationNumber`, `accountHolderContactNumber1`, `accountHolderContactNumber2`, `accountHolderEmailAddress`, `accountHolderAddressLine1`, `accountHolderAddressLine2`, `accountHolderAddressLine3`, `accountHolderPostalCode`, `timestamp`) "
-	insertStatement += "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+	insertStatement += "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 	stmtIns, err := Config.Db.Prepare(insertStatement)
 	if err != nil {
 		return errors.New("accounts.doCreateAccountUser: " + err.Error())

--- a/accounts/database.go
+++ b/accounts/database.go
@@ -104,7 +104,7 @@ func doDeleteAccount(accountDetails *AccountDetails) (err error) {
 
 func doCreateAccountMeta(sqlTime int32, accountHolderDetails *AccountHolderDetails, accountDetails *AccountDetails) (err error) {
 	// Create account meta
-	insertStatement := "INSERT INTO accounts_meta (`accountNumber`, `bankNumber`, `accountHolderGivenName`, `accountHolderFamilyName`, `accountHolderDateOfBirth`, `accountHolderIdentificationNumber`, `accountHolderContactNumber1`, `accountHolderContactNumber2`, `accountHolderEmailAddress`, `accountHolderAddressLine1`, `accountHolderAddressLine2`, `accountHolderAddressLine3`, `accountHolderPostalCode`, `timestamp`) "
+	insertStatement := "INSERT INTO accounts_users (`accountNumber`, `bankNumber`, `accountHolderGivenName`, `accountHolderFamilyName`, `accountHolderDateOfBirth`, `accountHolderIdentificationNumber`, `accountHolderContactNumber1`, `accountHolderContactNumber2`, `accountHolderEmailAddress`, `accountHolderAddressLine1`, `accountHolderAddressLine2`, `accountHolderAddressLine3`, `accountHolderPostalCode`, `timestamp`) "
 	insertStatement += "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 	stmtIns, err := Config.Db.Prepare(insertStatement)
 	if err != nil {
@@ -126,7 +126,7 @@ func doCreateAccountMeta(sqlTime int32, accountHolderDetails *AccountHolderDetai
 
 func doDeleteAccountMeta(accountHolderDetails *AccountHolderDetails, accountDetails *AccountDetails) (err error) {
 	// Create account meta
-	deleteStatement := "DELETE FROM accounts_meta WHERE `accountNumber` = ? AND `bankNumber` = ? AND `accountHolderGivenName` = ? AND `accountHolderFamilyName` = ? AND `accountHolderDateOfBirth` = ? AND `accountHolderIdentificationNumber` = ? AND `accountHolderContactNumber1` = ? AND `accountHolderContactNumber2` = ? AND `accountHolderEmailAddress` = ? AND `accountHolderAddressLine1` = ? AND `accountHolderAddressLine2` = ? AND `accountHolderAddressLine3` = ? AND `accountHolderPostalCode` = ? "
+	deleteStatement := "DELETE FROM accounts_users WHERE `accountNumber` = ? AND `bankNumber` = ? AND `accountHolderGivenName` = ? AND `accountHolderFamilyName` = ? AND `accountHolderDateOfBirth` = ? AND `accountHolderIdentificationNumber` = ? AND `accountHolderContactNumber1` = ? AND `accountHolderContactNumber2` = ? AND `accountHolderEmailAddress` = ? AND `accountHolderAddressLine1` = ? AND `accountHolderAddressLine2` = ? AND `accountHolderAddressLine3` = ? AND `accountHolderPostalCode` = ? "
 	stmtDel, err := Config.Db.Prepare(deleteStatement)
 	if err != nil {
 		return errors.New("accounts.doDeleteAccountMeta: " + err.Error())
@@ -174,7 +174,7 @@ func getAccountDetails(id string) (accountDetails AccountDetails, err error) {
 }
 
 func getAccountMeta(id string) (accountDetails AccountHolderDetails, err error) {
-	rows, err := Config.Db.Query("SELECT `accountNumber`, `bankNumber`, `accountHolderGivenName`, `accountHolderFamilyName`, `accountHolderDateOfBirth`, `accountHolderIdentificationNumber`, `accountHolderContactNumber1`, `accountHolderContactNumber2`, `accountHolderEmailAddress`, `accountHolderAddressLine1`, `accountHolderAddressLine2`, `accountHolderAddressLine3`, `accountHolderPostalCode` FROM `accounts_meta` WHERE `accountHolderIdentificationNumber` = ?", id)
+	rows, err := Config.Db.Query("SELECT `accountNumber`, `bankNumber`, `accountHolderGivenName`, `accountHolderFamilyName`, `accountHolderDateOfBirth`, `accountHolderIdentificationNumber`, `accountHolderContactNumber1`, `accountHolderContactNumber2`, `accountHolderEmailAddress`, `accountHolderAddressLine1`, `accountHolderAddressLine2`, `accountHolderAddressLine3`, `accountHolderPostalCode` FROM `accounts_users` WHERE `accountHolderIdentificationNumber` = ?", id)
 	if err != nil {
 		return AccountHolderDetails{}, errors.New("accounts.getAccountMeta: " + err.Error())
 	}
@@ -245,7 +245,7 @@ func getSingleAccountDetail(accountNumber string) (account AccountDetails, err e
 }
 
 func getSingleAccountNumberByID(userID string) (accountID string, err error) {
-	rows, err := Config.Db.Query("SELECT `accountNumber` FROM `accounts_meta` WHERE `accountHolderIdentificationNumber` = ?", userID)
+	rows, err := Config.Db.Query("SELECT `accountNumber` FROM `accounts_users` WHERE `accountHolderIdentificationNumber` = ?", userID)
 	if err != nil {
 		return "", errors.New("accounts.getSingleAccountNumberByID: " + err.Error())
 	}
@@ -337,7 +337,7 @@ func doDeleteAccountPushToken(accountNumber string, pushToken string, platform s
 }
 
 func getAccountFromSearchData(searchString string) (allAccountDetails []AccountHolderDetails, err error) {
-	rows, err := Config.Db.Query("SELECT `accountNumber`, `bankNumber`, `accountHolderGivenName`, `accountHolderFamilyName`, `accountHolderEmailAddress` FROM `accounts_meta` WHERE `accountHolderIdentificationNumber` = ? OR `accountHolderGivenName` = ? OR `accountHolderFamilyName` = ? OR  `accountHolderEmailAddress` = ? LIMIT 10", searchString, searchString, searchString, searchString)
+	rows, err := Config.Db.Query("SELECT `accountNumber`, `bankNumber`, `accountHolderGivenName`, `accountHolderFamilyName`, `accountHolderEmailAddress` FROM `accounts_users` WHERE `accountHolderIdentificationNumber` = ? OR `accountHolderGivenName` = ? OR `accountHolderFamilyName` = ? OR  `accountHolderEmailAddress` = ? LIMIT 10", searchString, searchString, searchString, searchString)
 	if err != nil {
 		return []AccountHolderDetails{}, errors.New("accounts.getAccountMeta: " + err.Error())
 	}
@@ -359,7 +359,7 @@ func getAccountFromSearchData(searchString string) (allAccountDetails []AccountH
 }
 
 func getAccountByHolderDetails(ID string, givenName string, familyName string, email string) (accountID string, err error) {
-	rows, err := Config.Db.Query("SELECT `accountNumber` FROM `accounts_meta` WHERE `accountHolderIdentificationNumber` = ? AND `accountHolderGivenName` = ? AND `accountHolderFamilyName` = ? AND `accountHolderEmailAddress` = ?", ID, givenName, familyName, email)
+	rows, err := Config.Db.Query("SELECT `accountNumber` FROM `accounts_users` WHERE `accountHolderIdentificationNumber` = ? AND `accountHolderGivenName` = ? AND `accountHolderFamilyName` = ? AND `accountHolderEmailAddress` = ?", ID, givenName, familyName, email)
 	if err != nil {
 		return "", errors.New("accounts.getAccountByHolderDetails: " + err.Error())
 	}

--- a/accounts/database.go
+++ b/accounts/database.go
@@ -224,7 +224,7 @@ func getAccountDetails(id string) (accountDetails AccountDetails, err error) {
 	}
 
 	if count > 1 {
-		//@TODO: Allow user to have multiple accounts
+		// There cannot be more than one account with the same accountNumber
 		return AccountDetails{}, errors.New("accounts.getAccountDetails: More than one account found")
 	}
 

--- a/accounts/database.go
+++ b/accounts/database.go
@@ -278,19 +278,27 @@ func getAllAccountDetails() (allAccounts []AccountDetails, err error) {
 	return
 }
 
-func getSingleAccountDetail(accountNumber string) (account AccountDetails, err error) {
-	rows, err := Config.Db.Query("SELECT `accountNumber`, `bankNumber`, `accountHolderName`, `accountBalance`, `overdraft`, `availableBalance` FROM `accounts` WHERE `accountNumber` = ?", accountNumber)
+func getUserAccountsDetail(userID string) (accounts []AccountDetails, err error) {
+	rows, err := Config.Db.Query(
+		"SELECT a.accountNumber, a.bankNumber, a.accountHolderName, a.accountBalance, a.overdraft, a.availableBalance "+
+			"FROM accounts a "+
+			"LEFT JOIN accounts_users_accounts au "+
+			"ON au.accountNumber = a.accountNumber "+
+			"AND au.bankNumber = a.bankNumber "+
+			"WHERE au.accountHolderIdentificationNumber = ?", userID)
 	if err != nil {
-		return AccountDetails{}, errors.New("accounts.getSingleAccountDetail: " + err.Error())
+		return nil, errors.New("accounts.getUserAccountsDetail: " + err.Error())
 	}
 	defer rows.Close()
 
 	count := 0
 	for rows.Next() {
+		var account AccountDetails
 		if err := rows.Scan(&account.AccountNumber, &account.BankNumber, &account.AccountHolderName, &account.AccountBalance, &account.Overdraft, &account.AvailableBalance); err != nil {
 			break
 		}
 
+		accounts = append(accounts, account)
 		count++
 	}
 

--- a/accounts/database.go
+++ b/accounts/database.go
@@ -73,8 +73,8 @@ func deleteAccount(accountDetails *AccountDetails, accountHolderDetails *Account
 
 func doCreateAccount(sqlTime int32, accountDetails *AccountDetails, accountHolderDetails *AccountHolderDetails) (err error) {
 	// Create account
-	insertStatement := "INSERT INTO accounts (`accountNumber`, `bankNumber`, `accountHolderName`, `accountBalance`, `overdraft`, `availableBalance`, `timestamp`) "
-	insertStatement += "VALUES(?, ?, ?, ?, ?, ?, ?)"
+	insertStatement := "INSERT INTO accounts (`accountNumber`, `bankNumber`, `accountHolderName`, `accountBalance`, `overdraft`, `availableBalance`, `type`, `timestamp`) "
+	insertStatement += "VALUES(?, ?, ?, ?, ?, ?, ?, ?)"
 	stmtIns, err := Config.Db.Prepare(insertStatement)
 	if err != nil {
 		return errors.New("accounts.doCreateAccount: " + err.Error())
@@ -87,7 +87,7 @@ func doCreateAccount(sqlTime int32, accountDetails *AccountDetails, accountHolde
 	newUuid := uuid.NewV4()
 	accountDetails.AccountNumber = newUuid.String()
 
-	_, err = stmtIns.Exec(accountDetails.AccountNumber, accountDetails.BankNumber, accountDetails.AccountHolderName, accountDetails.AccountBalance, accountDetails.Overdraft, accountDetails.AvailableBalance, sqlTime)
+	_, err = stmtIns.Exec(accountDetails.AccountNumber, accountDetails.BankNumber, accountDetails.AccountHolderName, accountDetails.AccountBalance, accountDetails.Overdraft, accountDetails.AvailableBalance, accountDetails.Type, sqlTime)
 	if err != nil {
 		return errors.New("accounts.doCreateAccount: " + err.Error())
 	}
@@ -129,6 +129,17 @@ func doDeleteAccount(accountDetails *AccountDetails) (err error) {
 }
 
 func doCreateAccountUser(sqlTime int32, accountHolderDetails *AccountHolderDetails, accountDetails *AccountDetails) (err error) {
+	// Check if the user already exists
+	account, err := getAccountUser(accountHolderDetails.IdentificationNumber)
+	if err != nil {
+		return errors.New("accounts.doCreateAccountUser: " + err.Error())
+	}
+
+	// If account is not empty it exists, return without creating a new one
+	if account != (AccountHolderDetails{}) {
+		return
+	}
+
 	// Create account meta
 	insertStatement := "INSERT INTO accounts_users (`accountHolderGivenName`, `accountHolderFamilyName`, `accountHolderDateOfBirth`, `accountHolderIdentificationNumber`, `accountHolderContactNumber1`, `accountHolderContactNumber2`, `accountHolderEmailAddress`, `accountHolderAddressLine1`, `accountHolderAddressLine2`, `accountHolderAddressLine3`, `accountHolderPostalCode`, `timestamp`) "
 	insertStatement += "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"

--- a/accounts/database_test.go
+++ b/accounts/database_test.go
@@ -55,12 +55,27 @@ func TestDoCreateAccount(t *testing.T) {
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
+		"cheque",
 		0,
+	}
+
+	accountHolderDetail := AccountHolderDetails{
+		"Test",
+		"User",
+		"1900-01-01",
+		"19000101-1000-100",
+		"555-123-1234",
+		"",
+		"test@user.com",
+		"Address 1",
+		"Address 2",
+		"Address 3",
+		"22202",
 	}
 
 	ti := time.Now()
 	sqlTime := int32(ti.Unix())
-	err := doCreateAccount(sqlTime, &accountDetail)
+	err := doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
 
 	if err != nil {
 		t.Errorf("DoCreateAccount does not pass. Looking for %v, got %v", nil, err)
@@ -81,72 +96,11 @@ func BenchmarkDoCreateAccount(b *testing.B) {
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
-			0,
-		}
-
-		ti := time.Now()
-		sqlTime := int32(ti.Unix())
-		_ = doCreateAccount(sqlTime, &accountDetail)
-		_ = doDeleteAccount(&accountDetail)
-	}
-}
-
-func TestDoAccountMeta(t *testing.T) {
-	accountDetail := AccountDetails{
-		"",
-		"",
-		"User,Test",
-		decimal.NewFromFloat(0.),
-		decimal.NewFromFloat(0.),
-		decimal.NewFromFloat(0.),
-		0,
-	}
-
-	accountHolderDetail := AccountHolderDetails{
-		"",
-		"",
-		"Test",
-		"User",
-		"1900-01-01",
-		"19000101-1000-100",
-		"555-123-1234",
-		"",
-		"test@user.com",
-		"Address 1",
-		"Address 2",
-		"Address 3",
-		"22202",
-	}
-
-	ti := time.Now()
-	sqlTime := int32(ti.Unix())
-	err := doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
-
-	if err != nil {
-		t.Errorf("DoAccountMeta CreateAccount does not pass. Looking for %v, got %v", nil, err)
-	}
-
-	err = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
-	if err != nil {
-		t.Errorf("DoAccountMeta DeleteAccount does not pass. Looking for %v, got %v", nil, err)
-	}
-}
-
-func BenchmarkDoAccountMeta(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		accountDetail := AccountDetails{
-			"",
-			"",
-			"User,Test",
-			decimal.NewFromFloat(0.),
-			decimal.NewFromFloat(0.),
-			decimal.NewFromFloat(0.),
+			"cheque",
 			0,
 		}
 
 		accountHolderDetail := AccountHolderDetails{
-			"",
-			"",
 			"Test",
 			"User",
 			"1900-01-01",
@@ -162,9 +116,83 @@ func BenchmarkDoAccountMeta(b *testing.B) {
 
 		ti := time.Now()
 		sqlTime := int32(ti.Unix())
-		_ = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+		_ = doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
+		_ = doDeleteAccount(&accountDetail)
+	}
+}
 
-		_ = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+func TestDoAccountMeta(t *testing.T) {
+	accountDetail := AccountDetails{
+		"",
+		"",
+		"User,Test",
+		decimal.NewFromFloat(0.),
+		decimal.NewFromFloat(0.),
+		decimal.NewFromFloat(0.),
+		"cheque",
+		0,
+	}
+
+	accountHolderDetail := AccountHolderDetails{
+		"Test",
+		"User",
+		"1900-01-01",
+		"19000101-1000-101",
+		"555-123-1234",
+		"",
+		"test@user.com",
+		"Address 1",
+		"Address 2",
+		"Address 3",
+		"22202",
+	}
+
+	ti := time.Now()
+	sqlTime := int32(ti.Unix())
+
+	err := doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
+	if err != nil {
+		t.Errorf("DoAccountMeta doCreateAccountUser does not pass. Looking for %v, got %v", nil, err)
+	}
+
+	err = doDeleteAccountUser(&accountHolderDetail)
+	if err != nil {
+		t.Errorf("DoAccountMeta doDeleteAccountUser does not pass. Looking for %v, got %v", nil, err)
+	}
+}
+
+func BenchmarkDoAccountMeta(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		accountDetail := AccountDetails{
+			"",
+			"",
+			"User,Test",
+			decimal.NewFromFloat(0.),
+			decimal.NewFromFloat(0.),
+			decimal.NewFromFloat(0.),
+			"cheque",
+			0,
+		}
+
+		accountHolderDetail := AccountHolderDetails{
+			"Test",
+			"User",
+			"1900-01-01",
+			"19000101-1000-100",
+			"555-123-1234",
+			"",
+			"test@user.com",
+			"Address 1",
+			"Address 2",
+			"Address 3",
+			"22202",
+		}
+
+		ti := time.Now()
+		sqlTime := int32(ti.Unix())
+		_ = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
+
+		_ = doDeleteAccountUser(&accountHolderDetail)
 	}
 }
 
@@ -176,12 +204,11 @@ func TestGetAccount(t *testing.T) {
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
+		"cheque",
 		0,
 	}
 
 	accountHolderDetail := AccountHolderDetails{
-		"",
-		"",
 		"Test",
 		"User",
 		"1900-01-01",
@@ -198,12 +225,12 @@ func TestGetAccount(t *testing.T) {
 	ti := time.Now()
 	sqlTime := int32(ti.Unix())
 
-	err := doCreateAccount(sqlTime, &accountDetail)
+	err := doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
 	if err != nil {
 		t.Errorf("GetAccount CreateAccount does not pass. Looking for %v, got %v", nil, err)
 	}
 
-	err = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+	err = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
 	if err != nil {
 		t.Errorf("GetAccount CreateAccountMeta does not pass. Looking for %v, got %v", nil, err)
 	}
@@ -242,7 +269,7 @@ func TestGetAccount(t *testing.T) {
 		t.Errorf("GetAccount DeleteAccount does not pass. Looking for %v, got %v", nil, err)
 	}
 
-	err = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+	err = doDeleteAccountUser(&accountHolderDetail)
 	if err != nil {
 		t.Errorf("GetAccount DeleteAccountMeta does not pass. Looking for %v, got %v", nil, err)
 	}
@@ -258,12 +285,11 @@ func BenchmarkDoGetAccount(b *testing.B) {
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
+			"cheque",
 			0,
 		}
 
 		accountHolderDetail := AccountHolderDetails{
-			"",
-			"",
 			"Test",
 			"User",
 			"1900-01-01",
@@ -280,12 +306,12 @@ func BenchmarkDoGetAccount(b *testing.B) {
 		ti := time.Now()
 		sqlTime := int32(ti.Unix())
 
-		_ = doCreateAccount(sqlTime, &accountDetail)
-		_ = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+		_ = doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
+		_ = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
 		// Get account
 		_, _ = getAccountDetails(accountDetail.AccountNumber)
 		_ = doDeleteAccount(&accountDetail)
-		_ = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+		_ = doDeleteAccountUser(&accountHolderDetail)
 	}
 }
 
@@ -297,12 +323,11 @@ func TestGetAccountMeta(t *testing.T) {
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
+		"cheque",
 		0,
 	}
 
 	accountHolderDetail := AccountHolderDetails{
-		"",
-		"",
 		"Test",
 		"User",
 		"1900-01-01",
@@ -319,29 +344,23 @@ func TestGetAccountMeta(t *testing.T) {
 	ti := time.Now()
 	sqlTime := int32(ti.Unix())
 
-	err := doCreateAccount(sqlTime, &accountDetail)
+	err := doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
 	if err != nil {
 		t.Errorf("GetAccountMeta CreateAccount does not pass. Looking for %v, got %v", nil, err)
 	}
 
-	err = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+	err = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
 	if err != nil {
 		t.Errorf("GetAccountMeta CreateAccountMeta does not pass. Looking for %v, got %v", nil, err)
 	}
 
 	// Get account
-	getAccountDetails, err := getAccountMeta(accountHolderDetail.IdentificationNumber)
+	getAccountDetails, err := getAccountUser(accountHolderDetail.IdentificationNumber)
 	if err != nil {
 		t.Errorf("GetAccountMeta does not pass. Looking for %v, got %v", nil, err)
 		return
 	}
 	//Check values
-	if getAccountDetails.AccountNumber != accountDetail.AccountNumber {
-		t.Errorf("GetAccountMeta does not pass. DETAILS. AccountNumber: Looking for %v, got %v", accountDetail.AccountNumber, getAccountDetails.AccountNumber)
-	}
-	if getAccountDetails.BankNumber != "" {
-		t.Errorf("GetAccountMeta does not pass. DETAILS. BankNumber: Looking for %v, got %v", "", getAccountDetails.BankNumber)
-	}
 	if getAccountDetails.GivenName != "Test" {
 		t.Errorf("GetAccountMeta does not pass. DETAILS. GivenName: Looking for %v, got %v", "Test", getAccountDetails.GivenName)
 	}
@@ -381,7 +400,7 @@ func TestGetAccountMeta(t *testing.T) {
 		t.Errorf("GetAccountMeta DeleteAccount does not pass. Looking for %v, got %v", nil, err)
 	}
 
-	err = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+	err = doDeleteAccountUser(&accountHolderDetail)
 	if err != nil {
 		t.Errorf("GetAccountMeta DeleteAccountMeta does not pass. Looking for %v, got %v", nil, err)
 	}
@@ -396,12 +415,11 @@ func BenchmarkDoGetAccountMeta(b *testing.B) {
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
+			"cheque",
 			0,
 		}
 
 		accountHolderDetail := AccountHolderDetails{
-			"",
-			"",
 			"Test",
 			"User",
 			"1900-01-01",
@@ -418,12 +436,12 @@ func BenchmarkDoGetAccountMeta(b *testing.B) {
 		ti := time.Now()
 		sqlTime := int32(ti.Unix())
 
-		_ = doCreateAccount(sqlTime, &accountDetail)
-		_ = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+		_ = doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
+		_ = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
 		// Get account
-		_, _ = getAccountMeta(accountHolderDetail.IdentificationNumber)
+		_, _ = getAccountUser(accountHolderDetail.IdentificationNumber)
 		_ = doDeleteAccount(&accountDetail)
-		_ = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+		_ = doDeleteAccountUser(&accountHolderDetail)
 	}
 }
 
@@ -453,12 +471,11 @@ func TestGetSingleAccountDetail(t *testing.T) {
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
+		"cheque",
 		0,
 	}
 
 	accountHolderDetail := AccountHolderDetails{
-		"",
-		"",
 		"Test",
 		"User",
 		"1900-01-01",
@@ -475,18 +492,18 @@ func TestGetSingleAccountDetail(t *testing.T) {
 	ti := time.Now()
 	sqlTime := int32(ti.Unix())
 
-	err := doCreateAccount(sqlTime, &accountDetail)
+	err := doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
 	if err != nil {
 		t.Errorf("GetSingleAccountDetail CreateAccount does not pass. Looking for %v, got %v", nil, err)
 	}
 
-	err = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+	err = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
 	if err != nil {
 		t.Errorf("GetSingleAccountDetail CreateAccountMeta does not pass. Looking for %v, got %v", nil, err)
 	}
 
 	// Do get account call
-	getAccountDetails, err := getSingleAccountDetail(accountDetail.AccountNumber)
+	getAccountDetails, err := getAccountDetails(accountDetail.AccountNumber)
 	if err != nil {
 		t.Errorf("GetSingleAccountDetail does not pass. Looking for %v, got %v", nil, err)
 	}
@@ -516,7 +533,7 @@ func TestGetSingleAccountDetail(t *testing.T) {
 		t.Errorf("GetSingleAccountDetail DeleteAccount does not pass. Looking for %v, got %v", nil, err)
 	}
 
-	err = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+	err = doDeleteAccountUser(&accountHolderDetail)
 	if err != nil {
 		t.Errorf("GetSingleAccountDetail DeleteAccountMeta does not pass. Looking for %v, got %v", nil, err)
 	}
@@ -531,12 +548,11 @@ func BenchmarkGetSingleAccountDetail(b *testing.B) {
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
+			"cheque",
 			0,
 		}
 
 		accountHolderDetail := AccountHolderDetails{
-			"",
-			"",
 			"Test",
 			"User",
 			"1900-01-01",
@@ -553,12 +569,12 @@ func BenchmarkGetSingleAccountDetail(b *testing.B) {
 		ti := time.Now()
 		sqlTime := int32(ti.Unix())
 
-		_ = doCreateAccount(sqlTime, &accountDetail)
-		_ = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+		_ = doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
+		_ = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
 		// Do get account call
-		_, _ = getSingleAccountDetail(accountDetail.AccountNumber)
+		_, _ = getAccountDetails(accountDetail.AccountNumber)
 		_ = doDeleteAccount(&accountDetail)
-		_ = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+		_ = doDeleteAccountUser(&accountHolderDetail)
 	}
 }
 
@@ -570,16 +586,15 @@ func TestGetSingleAccountNumberByID(t *testing.T) {
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
 		decimal.NewFromFloat(0.),
+		"cheque",
 		0,
 	}
 
 	accountHolderDetail := AccountHolderDetails{
-		"",
-		"",
 		"Test",
 		"User",
 		"1900-01-01",
-		"19000101-1000-100",
+		"19000101-1000-102",
 		"555-123-1234",
 		"",
 		"test@user.com",
@@ -592,25 +607,27 @@ func TestGetSingleAccountNumberByID(t *testing.T) {
 	ti := time.Now()
 	sqlTime := int32(ti.Unix())
 
-	err := doCreateAccount(sqlTime, &accountDetail)
+	err := doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
 	if err != nil {
 		t.Errorf("GetSingleAccountNumberByID CreateAccount does not pass. Looking for %v, got %v", nil, err)
 	}
 
-	err = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+	err = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
 	if err != nil {
 		t.Errorf("GetSingleAccountNumberByID CreateAccountMeta does not pass. Looking for %v, got %v", nil, err)
 	}
 
 	// Do get account call
-	getAccountNumber, err := getSingleAccountNumberByID(accountHolderDetail.IdentificationNumber)
+	accounts, err := getAllAccountNumbersByID(accountHolderDetail.IdentificationNumber)
 	if err != nil {
 		t.Errorf("GetSingleAccountNumberByID does not pass. Looking for %v, got %v", nil, err)
 	}
 
 	//Check values
-	if getAccountNumber != accountDetail.AccountNumber {
-		t.Errorf("GetSingleAccountNumberByID does not pass. DETAILS. AccountNumber: Looking for %v, got %v", getAccountNumber, accountDetail.AccountNumber)
+	for _, getAccountNumber := range accounts {
+		if getAccountNumber != accountDetail.AccountNumber {
+			t.Errorf("GetSingleAccountNumberByID does not pass. DETAILS. AccountNumber: Looking for %v, got %v", getAccountNumber, accountDetail.AccountNumber)
+		}
 	}
 
 	err = doDeleteAccount(&accountDetail)
@@ -618,7 +635,7 @@ func TestGetSingleAccountNumberByID(t *testing.T) {
 		t.Errorf("GetSingleAccountNumberByID DeleteAccount does not pass. Looking for %v, got %v", nil, err)
 	}
 
-	err = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+	err = doDeleteAccountUser(&accountHolderDetail)
 	if err != nil {
 		t.Errorf("GetSingleAccountNumberByID DeleteAccountMeta does not pass. Looking for %v, got %v", nil, err)
 	}
@@ -633,12 +650,11 @@ func BenchmarkGetSingleAccountNumberByID(b *testing.B) {
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
 			decimal.NewFromFloat(0.),
+			"cheque",
 			0,
 		}
 
 		accountHolderDetail := AccountHolderDetails{
-			"",
-			"",
 			"Test",
 			"User",
 			"1900-01-01",
@@ -655,12 +671,12 @@ func BenchmarkGetSingleAccountNumberByID(b *testing.B) {
 		ti := time.Now()
 		sqlTime := int32(ti.Unix())
 
-		_ = doCreateAccount(sqlTime, &accountDetail)
-		_ = doCreateAccountMeta(sqlTime, &accountHolderDetail, &accountDetail)
+		_ = doCreateAccount(sqlTime, &accountDetail, &accountHolderDetail)
+		_ = doCreateAccountUser(sqlTime, &accountHolderDetail, &accountDetail)
 		// Do get account call
-		_, _ = getSingleAccountNumberByID(accountHolderDetail.IdentificationNumber)
+		_, _ = getAllAccountNumbersByID(accountHolderDetail.IdentificationNumber)
 		_ = doDeleteAccount(&accountDetail)
-		_ = doDeleteAccountMeta(&accountHolderDetail, &accountDetail)
+		_ = doDeleteAccountUser(&accountHolderDetail)
 	}
 }
 

--- a/appauth/auth.go
+++ b/appauth/auth.go
@@ -80,7 +80,7 @@ func CreateUserPassword(user string, clearTextPassword string) (result string, e
 	//TEST 0~appauth~3~181ac0ae-45cb-461d-b740-15ce33e4612f~testPassword
 
 	// Check for existing account
-	rows, err := Config.Db.Query("SELECT `accountNumber` FROM `accounts_auth` WHERE `accountNumber` = ?", user)
+	rows, err := Config.Db.Query("SELECT `accountNumber` FROM `accounts_user_auth` WHERE `accountHolderIdentificationNumber` = ?", user)
 	if err != nil {
 		return "", errors.New("appauth.CreateUserPassword: Error with select query. " + err.Error())
 	}
@@ -118,7 +118,7 @@ func CreateUserPassword(user string, clearTextPassword string) (result string, e
 	userHashedPassword := hex.EncodeToString(hashOutput)
 
 	// Prepare statement for inserting data
-	insertStatement := "INSERT INTO accounts_auth (`accountNumber`, `password`, `salt`, `timestamp`) "
+	insertStatement := "INSERT INTO accounts_user_auth (`accountHolderIdentificationNumber`, `password`, `salt`, `timestamp`) "
 	insertStatement += "VALUES(?, ?, ?, ?)"
 	stmtIns, err := Config.Db.Prepare(insertStatement)
 	if err != nil {
@@ -142,7 +142,7 @@ func CreateUserPassword(user string, clearTextPassword string) (result string, e
 
 func RemoveUserPassword(user string, clearTextPassword string) (result string, err error) {
 	// Check for existing account
-	rows, err := Config.Db.Query("SELECT `accountNumber` FROM `accounts_auth` WHERE `accountNumber` = ?", user)
+	rows, err := Config.Db.Query("SELECT `accountNumber` FROM `accounts_user_auth` WHERE `accountHolderIdentificationNumber` = ?", user)
 	if err != nil {
 		return "", errors.New("appauth.RemoveUserPassword: Error with select query. " + err.Error())
 	}
@@ -176,7 +176,7 @@ func RemoveUserPassword(user string, clearTextPassword string) (result string, e
 	}
 
 	// Prepare statement for inserting data
-	delStatement := "DELETE FROM accounts_auth WHERE `accountNumber` = ? AND `password` = ? "
+	delStatement := "DELETE FROM accounts_user_auth WHERE `accountHolderIdentificationNumber` = ? AND `password` = ? "
 	stmtDel, err := Config.Db.Prepare(delStatement)
 	if err != nil {
 		return "", errors.New("appauth.RemoveUserPassword: Error with delete. " + err.Error())
@@ -203,7 +203,7 @@ func RemoveUserPassword(user string, clearTextPassword string) (result string, e
 }
 
 func CreateToken(user string, password string) (token string, err error) {
-	rows, err := Config.Db.Query("SELECT `password`, `salt` FROM `accounts_auth` WHERE `accountNumber` = ?", user)
+	rows, err := Config.Db.Query("SELECT `password`, `salt` FROM `accounts_user_auth` WHERE `accountHolderIdentificationNumber` = ?", user)
 	if err != nil {
 		return "", errors.New("appauth.CreateToken: Error with select query. " + err.Error())
 	}
@@ -305,7 +305,7 @@ func RandStringBytes(n int) string {
 }
 
 func getUserPasswordSaltFromUID(user string) (hashedPassword string, userSalt string, err error) {
-	rows, err := Config.Db.Query("SELECT `password`, `salt` FROM `accounts_auth` WHERE `accountNumber` = ?", user)
+	rows, err := Config.Db.Query("SELECT `password`, `salt` FROM `accounts_user_auth` WHERE `accountHolderIdentificationNumber` = ?", user)
 	if err != nil {
 		return "", "", errors.New("appauth.CreateToken: Error with select query. " + err.Error())
 	}

--- a/httpApiHandlers.go
+++ b/httpApiHandlers.go
@@ -60,10 +60,10 @@ func AuthLogin(w http.ResponseWriter, r *http.Request) {
 
 // Create auth account
 func AuthCreate(w http.ResponseWriter, r *http.Request) {
-	user := r.FormValue("User")
+	userID := r.FormValue("UserIdentificationNumber")
 	password := r.FormValue("Password")
 
-	response, err := appauth.ProcessAppAuth([]string{"0", "appauth", "3", user, password})
+	response, err := appauth.ProcessAppAuth([]string{"0", "appauth", "3", userID, password})
 	Response(response, err, w, r)
 	return
 }

--- a/httpApiHandlers.go
+++ b/httpApiHandlers.go
@@ -110,6 +110,7 @@ func AccountCreate(w http.ResponseWriter, r *http.Request) {
 	accountHolderAddressLine2 := r.FormValue("AccountHolderAddressLine2")
 	accountHolderAddressLine3 := r.FormValue("AccountHolderAddressLine3")
 	accountHolderPostalCode := r.FormValue("AccountHolderPostalCode")
+	accountType := r.FormValue("AccountType")
 
 	req := []string{
 		"0",
@@ -126,6 +127,7 @@ func AccountCreate(w http.ResponseWriter, r *http.Request) {
 		accountHolderAddressLine2,
 		accountHolderAddressLine3,
 		accountHolderPostalCode,
+		accountType,
 	}
 
 	response, err := accounts.ProcessAccount(req)

--- a/httpApiHandlers.go
+++ b/httpApiHandlers.go
@@ -259,13 +259,19 @@ func TransactionList(w http.ResponseWriter, r *http.Request) {
 		Response("", err, w, r)
 		return
 	}
+	// Get account number from header
+	accountNumber := r.Header.Get("X-Auth-AccountNumber")
+	if accountNumber == "" {
+		Response("", errors.New("httpApiHandlers.TransactionList: Could not retrieve accountNumber from headers"), w, r)
+		return
+	}
 
 	vars := mux.Vars(r)
 	perPage := vars["perPage"]
 	page := vars["page"]
 	timestamp := vars["timestamp"]
 
-	response, err := transactions.ProcessPAIN([]string{token, "pain", "1001", page, perPage, timestamp})
+	response, err := transactions.ProcessPAIN([]string{token, "pain", "1001", accountNumber, page, perPage, timestamp})
 	Response(response, err, w, r)
 	return
 }

--- a/sql/10-change_accounts_meta_to_accounts_users.sql
+++ b/sql/10-change_accounts_meta_to_accounts_users.sql
@@ -1,0 +1,1 @@
+RENAME TABLE `accounts_meta` TO `accounts_users`;

--- a/sql/11-create-accounts-users-accounts-table.sql
+++ b/sql/11-create-accounts-users-accounts-table.sql
@@ -1,0 +1,11 @@
+/*
+Accounts users accounts table links a single accounts user to many accounts
+*/
+CREATE TABLE IF NOT EXISTS accounts_users_accounts (
+`id` int NOT NULL AUTO_INCREMENT,
+`accountHolderIdentificationNumber` text NOT NULL, 
+`accountNumber` char(36) NOT NULL, 
+`bankNumber` char(36) NOT NULL, 
+`timestamp` int NOT NULL, 
+PRIMARY KEY (`id`)
+);

--- a/sql/12-copy-existing-account-data-to-users-table.sql
+++ b/sql/12-copy-existing-account-data-to-users-table.sql
@@ -1,0 +1,6 @@
+/*
+We copy the existing data over to the new table
+*/
+INSERT INTO accounts_users_accounts (`accountHolderIdentificationNumber`, `accountNumber`, `bankNumber`, `timestamp`)
+SELECT `accountHolderIdentificationNumber`, `accountNumber`, `bankNumber`, `timestamp`
+FROM accounts_users;

--- a/sql/13-remove-account-balance-fields-from-accounts-users.sql
+++ b/sql/13-remove-account-balance-fields-from-accounts-users.sql
@@ -1,0 +1,3 @@
+ALTER table accounts_users
+DROP column `accountNumber`, 
+DROP column `bankNumber`;

--- a/sql/14-change-accounts-auth.sql
+++ b/sql/14-change-accounts-auth.sql
@@ -1,0 +1,11 @@
+RENAME TABLE `accounts_auth` TO `accounts_user_auth`;
+
+/*
+@TODO Create migration where the current accountNumbers are replaced with the users identification number
+*/
+
+DROP INDEX account_auth_num ON `accounts_user_auth`;
+ALTER TABLE `accounts_user_auth` CHANGE `accountNumber` `accountHolderIdentificationNumber` VARCHAR(200);
+CREATE INDEX account_auth_num ON accounts_user_auth(accountHolderIdentificationNumber);
+
+

--- a/sql/15-add-authuser-to-accounts-auth.sql
+++ b/sql/15-add-authuser-to-accounts-auth.sql
@@ -1,0 +1,6 @@
+ALTER TABLE accounts_user_auth 
+ADD `authUser` char(36) NOT NULL
+AFTER `accountHolderIdentificationNumber`;
+
+/* Here we reset the table as the authUser will be blank */
+TRUNCATE TABLE accounts_user_auth;

--- a/sql/16-add-account-type.sql
+++ b/sql/16-add-account-type.sql
@@ -1,0 +1,4 @@
+ALTER TABLE accounts 
+ADD `type` enum('savings', 'cheque', 'merchant', 'money-market', 'cd', 'ira', 'rcp', 'credit', 'mortgage', 'loan') NOT NULL DEFAULT 'cheque'
+AFTER `availableBalance`;
+

--- a/transactions/transactions.go
+++ b/transactions/transactions.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bvnk/bank/accounts"
 	"github.com/bvnk/bank/appauth"
 	"github.com/bvnk/bank/push"
 	"github.com/paulmach/go.geo"
@@ -126,7 +127,9 @@ func painCreditTransferInitiation(painType int64, data []string) (result string,
 	if err != nil {
 		return "", errors.New("payments.painCreditTransferInitiation: " + err.Error())
 	}
-	if tokenUser != sender.AccountNumber {
+	//
+	err = accounts.CheckUserAccountValidFromToken(tokenUser, sender.AccountNumber)
+	if err != nil {
 		return "", errors.New("payments.painCreditTransferInitiation: Sender not valid")
 	}
 


### PR DESCRIPTION
## PR notes

This PR brings a number of big changes. These are mainly focused around a user having multiple accounts linked to them. 

User accounts are created as normal and many may be created against a single user identification number. When creating the auth for the account, a new variable is introduced to act as a unique identifier against a userIdentificationNumber. This variable, `authUser`, is then used as the `User` variable when signing in to get an `authToken`. This is done primarily to not send through an ID number on every request for privacy reasons.

As multiple accounts are now returned, `accountGet` returns an array of accounts. `TransactionList` also now requires a new header variable to be sent through, `X-Auth-AccountNumber`, which identifies which account the request is retrieving the transactions for.

Account types have also been added. The default account type is 'cheque' and currently can be one of: 'savings', 'cheque', 'merchant', 'money-market', 'cd', 'ira', 'rcp', 'credit', 'mortgage', 'loan'. When creating an account, an additional filed `AccountType` must be sent through. If the field is included but is blank, 'cheque' is chosen as the default.

The postman file is available for download and import at [https://bvnk.co/Bvnk.postman_collection.json](https://bvnk.co/Bvnk.postman_collection.json)

### Migration path
To migrate the installation, the following sql scripts need to be run. __Please note:__ all existing authentication credentials will be deleted and will need to be recreated. This is detailed below.

Sql scripts:

```
sql/10-change_accounts_meta_to_accounts_users.sql
sql/11-create-accounts-users-accounts-table.sql
sql/12-copy-existing-account-data-to-users-table.sql
sql/13-remove-account-balance-fields-from-accounts-users.sql
sql/14-change-accounts-auth.sql
sql/15-add-authuser-to-accounts-auth.sql
```

To create an authentication user/password:

```
curl --request POST \
  --url https://bvnk.co:8443/auth/account \
  --header 'cache-control: no-cache' \
  --header 'content-type: multipart/form-data; boundary=---011000010111000001101001' \
  --form UserIdentificationNumber=19000101-1234-124 \
  --form Password=TestPassword
```

The response will be a new UUID authUser, or if this account already exists an error with the existing authUser number.

```
2fe198f4-b953-4766-9d2a-bb6e9bc9be4f
```

To log in and get a token using this authUser UUID:

```
curl --request POST \
  --url https://bvnk.co:8443/auth/login \
  --header 'cache-control: no-cache' \
  --header 'content-type: multipart/form-data; boundary=---011000010111000001101001' \
  --form User=2fe198f4-b953-4766-9d2a-bb6e9bc9be4f \
  --form Password=TestPassword
```

As is seen in the above code, the `User` POST variable is now the authUser variable. 

The flow is now the same as before, with a token being returned and that token being sent on subsequent requests.

### Other changes

- getAllAccounts has been deprecated.
- token validation is done against the user, which is then checked against all valid accounts the user has.